### PR TITLE
Readme: simplify tape-watch invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Say your project has a `test` folder, which includes `index.js`, a main entry po
 
     ...
     "scripts": {
-      "test": "node node_modules/tape-watch/bin/tape-watch test/index.js 2>&1 | tape-growl | tap-spec"
+      "test": "tape-watch test/index.js 2>&1 | tape-growl | tap-spec"
     },
     ...
 


### PR DESCRIPTION
npm already adds `./node_modules/.bin` to your PATH in scripts, so the whole `node node_modules/x/bin/...` dance isn't necessary :)
